### PR TITLE
Update version to 21.0.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,6 +79,7 @@ build:
     - $RPATH/libXxf86vm.so.1
     - $RPATH/libXcursor.so.1
     - $RPATH/libstdc++.so.6
+    - $RPATH/libudev.so.1               # [linux]
     - $RPATH/libjvm.dylib               # [osx]
     - $RPATH/libjawt.dylib              # [osx]
     - $RPATH/libpangoft2-1.0.so.0       # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -124,6 +124,7 @@ requirements:
     - expat {{ expat }}        # [linux]
     - freetype {{ freetype }}  # [linux]
     - glib {{ glib }}          # [linux]
+    # new version of libxcb provoke an overlinking errors
     - libxcb 1.15              # [linux]
     - pango {{ pango }}        # [linux]
     - zlib {{ zlib }}          # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,9 @@ build:
     - libxcb             # [linux]
     - zlib               # [osx]
     - glib               # [linux]
+    - xorg-libx11        # [linux]
+    - xorg-libxext       # [linux]
+    - xorg-libxrender    # [linux]
   missing_dso_whitelist:
     - $RPATH/libz.so.1
     - $RPATH/libjli.so

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ build:
     - $RPATH/libgdk-x11-2.0.so.0        # [linux and aarch64]
     - $RPATH/libgdk_pixbuf-2.0.so.0     # [linux and aarch64]
     - $RPATH/libgthread-2.0.so.0        # [linux and aarch64]
-    - $RPATH/ld-linux-x86-64.so.2       # [linux and (aarch64 or s390x or ppc64le)]
+    - $RPATH/ld-linux-x86-64.so.2       # [linux and aarch64]
     - $RPATH/libgtk-3.so.0              # [linux and aarch64]
     - $RPATH/libgdk-3.so.0              # [linux and aarch64]
     - $RPATH/libavcodec-ffmpeg.so.56    # [linux and aarch64]
@@ -124,8 +124,8 @@ requirements:
     - expat {{ expat }}        # [linux]
     - freetype {{ freetype }}  # [linux]
     - glib {{ glib }}          # [linux]
-    - libxcb 1.15              # [linux]
-    - pango 1.50.7             # [linux]
+    - libxcb {{ libxcb }}      # [linux]
+    - pango {{ pango }}        # [linux]
     - zlib {{ zlib }}          # [unix]
   run:
     - cairo                    # [linux]
@@ -138,6 +138,7 @@ requirements:
  
 test:
   requires:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   files:
     - test-jni     # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,9 +46,6 @@ build:
     - libxcb             # [linux]
     - zlib               # [osx]
     - glib               # [linux]
-    - xorg-libx11        # [linux]
-    - xorg-libxext       # [linux]
-    - xorg-libxrender    # [linux]
   missing_dso_whitelist:
     - $RPATH/libz.so.1
     - $RPATH/libjli.so
@@ -127,7 +124,7 @@ requirements:
     - expat {{ expat }}        # [linux]
     - freetype {{ freetype }}  # [linux]
     - glib {{ glib }}          # [linux]
-    - libxcb {{ libxcb }}      # [linux]
+    - libxcb 1.15              # [linux]
     - pango {{ pango }}        # [linux]
     - zlib {{ zlib }}          # [unix]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,52 +1,44 @@
 # Based on recipes from birdhouse and anaconda channel.
 
 {% set name = "openjdk" %}
-{% set version = "21.0.6" %}
-{% set intellij_build = "895.97" %}
+{% set version = "21.0.11" %}
+{% set intellij_build = "1163.116" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-{{ version }}-osx-x64-b{{ intellij_build }}.tar.gz                       # [osx and not arm64]
-    fn: jbrsdk-{{ version }}-osx-x64-b{{ intellij_build }}.tar.gz                                                                            # [osx and not arm64]
-    sha256: d872b655624d173edf576873a840c3d9c5b6cbf5184c93d51d916341749148cd                                                                 # [osx and not arm64]
-  - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-{{ version }}-osx-x64-b{{ intellij_build }}.tar.gz                     # [osx and not arm64]
-    fn: jbr_jcef-{{ version }}-osx-x64-b{{ intellij_build }}.tar.gz                                                                          # [osx and not arm64]
-    sha256: 0c0e081cba37ad890dc02ac744025925f9852cd0aa97f393304f7682ad721c58                                                                 # [osx and not arm64]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-{{ version }}-osx-aarch64-b{{ intellij_build }}.tar.gz                   # [osx and arm64]
     fn: jbrsdk-{{ version }}-osx-aarch64-b{{ intellij_build }}.tar.gz                                                                        # [osx and arm64]
-    sha256: 9df625d6f7a8b33236d4b8c4796c58f90f6b76c57b4c4a0a46c47fe2e88e3f17                                                                 # [osx and arm64]
+    sha256: ff2d12e6cf6b2f9d7793b8b6596afe413bdd4074fbfc91d9a36f379df61df182                                                                 # [osx and arm64]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-{{ version }}-osx-aarch64-b{{ intellij_build }}.tar.gz                 # [osx and arm64]
     fn: jbr_jcef-{{ version }}-osx-aarch64-b{{ intellij_build }}.tar.gz                                                                      # [osx and arm64]
-    sha256: 53a8d285e288ea827d87f5de5556843570a8081a46fdad0c3357445787f0dcb7                                                                 # [osx and arm64]
+    sha256: 1f6835ee1445c28c1093e421a7c2f7e950aed5b632febf728778438fd078ab3c                                                                 # [osx and arm64]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-{{ version }}-linux-x64-b{{ intellij_build }}.tar.gz                     # [linux and not aarch64]
     fn: jbrsdk-{{ version }}-linux-x64-b{{ intellij_build }}.tar.gz                                                                          # [linux and not aarch64]
-    sha256: 0d253d7995c4767e0c3e1ce090f0497b8f74e4a0240001695102690f64d18397                                                                 # [linux and not aarch64]
+    sha256: 097bf328b5bf5a236c095b8c8e5204c0eda91e5baa06b37383a7754b10671d8b                                                                 # [linux and not aarch64]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-{{ version }}-linux-x64-b{{ intellij_build }}.tar.gz                   # [linux and not aarch64]
     fn: jbr_jcef-{{ version }}-linux-x64-b{{ intellij_build }}.tar.gz                                                                        # [linux and not aarch64]
-    sha256: d0f1c9979e5ce97f942de6fe8bacd641aa6be5f204eedd00cd55e3b1ebd9ea48                                                                 # [linux and not aarch64]
+    sha256: 29bc13ce14b7ddb25cc03516c7d941a9c9ad6cdc5424b3e61087d194819fb483                                                                 # [linux and not aarch64]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-{{ version }}-linux-aarch64-b{{ intellij_build }}.tar.gz                 # [linux and aarch64]
     fn: jbrsdk-{{ version }}-linux-aarch64-b{{ intellij_build }}.tar.gz                                                                      # [linux and aarch64]
-    sha256: a5e35916ab77f86a1d903850fc62560fc5c3fd1933b1cfbd1eb06d39f68ffba5                                                                 # [linux and aarch64]
+    sha256: 21ff925581865d97da97df5c8bdb2ab320dbf6aa609a6556efe3c9a7a7c62db2                                                                 # [linux and aarch64]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-{{ version }}-linux-aarch64-b{{ intellij_build }}.tar.gz               # [linux and aarch64]
     fn: jbr_jcef-{{ version }}-linux-aarch64-b{{ intellij_build }}.tar.gz                                                                    # [linux and aarch64]
-    sha256: df21732145817795e4d77c94690f54b9d29ab73995a4dc0c89313199aa14eea1                                                                 # [linux and aarch64]
+    sha256: 159d5f32a45461a76ba67803a4b8f456398ec80729534bb77603eb5fb048d610                                                                 # [linux and aarch64]
   - url: https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip                               # [linux]
     sha256: 7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a                                                                 # [linux]
     folder: fonts                                                                                                                            # [linux]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-{{ version }}-windows-x64-b{{ intellij_build }}.tar.gz                   # [win64]
     fn: jbrsdk-{{ version }}-windows-x64-b{{ intellij_build }}.tar.gz                                                                        # [win64]
-    sha256: 1cc76557ae6df315c9487e067f54b109a28a47f846b8238c1e313bea4e4b5c07                                                                 # [win64]
+    sha256: a3b01a47e67207722064c136616a3c0529e0dc96e17d0d5e44a0e8b4a92c57e7                                                                 # [win64]
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-{{ version }}-windows-x64-b{{ intellij_build }}.tar.gz                 # [win64]
     fn: jbr_jcef-{{ version }}-windows-x64-b{{ intellij_build }}.tar.gz                                                                      # [win64]
-    sha256: ace0a8e434ca1161f7968588e1efa4f8a408493bf74f13886f1cf51dc6e65083                                                                 # [win64]
+    sha256: 40a305663ded81fd49f11bb314253026df6a54b18e919bea2fc184c8f72ef23b                                                                 # [win64]
 
 build:
   number: 0
-  # openjdk 21.0.6 is not currently supported on ppc64le or s390x.
-  skip: True  # [ppc64le or s390x]
   ignore_run_exports:
     - dbus               # [linux]
     - expat              # [linux]
@@ -102,7 +94,6 @@ build:
     - $RPATH/libGL.so.1                 # [linux and aarch64]
     - $RPATH/libgmodule-2.0.so.0        # [linux and aarch64]
     - /*/*/*/*/*/*/*/Frameworks/JavaNativeFoundation.framework/JavaNativeFoundation       # [osx and arm64]
-    - /*/*/*/*/*/*/Frameworks/JavaRuntimeSupport.framework/Versions/A/JavaRuntimeSupport  # [osx and x86_64]
     - Library\bin\VCRUNTIME140.dll        # [win]
     - Library\bin\VCRUNTIME140_1.dll      # [win]
     - Library\bin\bin\VCRUNTIME140.dll    # [win]
@@ -120,10 +111,10 @@ build:
     - $RPATH/api-ms-win-power-setting-l1-1-0.dll      # [win]
     - $RPATH/libwayland-client.so.0
     - $RPATH/libwayland-cursor.so.0
-    - /System/Library/Frameworks/UniformTypeIdentifiers.framework/Versions/A/UniformTypeIdentifiers  # [osx and x86_64]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - zip                      # [linux]
   host:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -9,3 +9,107 @@ pushd test-nio
   java -jar TestFilePaths.jar TestFilePaths.java
   IF ERRORLEVEL 1 exit 1
 popd
+
+@echo off
+echo Checking binaries...
+for %%f in (
+    Library\bin\jar.exe
+    Library\bin\jarsigner.exe
+    Library\bin\java.exe
+    Library\bin\javac.exe
+    Library\bin\javadoc.exe
+    Library\bin\javap.exe
+    Library\bin\javaw.exe
+    Library\bin\jcmd.exe
+    Library\bin\jconsole.exe
+    Library\bin\jdb.exe
+    Library\bin\jdeprscan.exe
+    Library\bin\jdeps.exe
+    Library\bin\jfr.exe
+    Library\bin\jhsdb.exe
+    Library\bin\jimage.exe
+    Library\bin\jinfo.exe
+    Library\bin\jlink.exe
+    Library\bin\jmap.exe
+    Library\bin\jmod.exe
+    Library\bin\jpackage.exe
+    Library\bin\jps.exe
+    Library\bin\jrunscript.exe
+    Library\bin\jshell.exe
+    Library\bin\jstack.exe
+    Library\bin\jstat.exe
+    Library\bin\jstatd.exe
+    Library\bin\jwebserver.exe
+    Library\bin\keytool.exe
+    Library\bin\rmiregistry.exe
+    Library\bin\serialver.exe
+) do (
+    if not exist "%PREFIX%\%%f" (
+        echo MISSING binary: %%f
+        exit /b 1
+    )
+)
+
+echo Checking libraries...
+for %%f in (
+    Library\bin\attach.dll
+    Library\bin\awt.dll
+    Library\bin\dt_socket.dll
+    Library\bin\extnet.dll
+    Library\bin\fontmanager.dll
+    Library\bin\freetype.dll
+    Library\bin\instrument.dll
+    Library\bin\j2gss.dll
+    Library\bin\j2pcsc.dll
+    Library\bin\j2pkcs11.dll
+    Library\bin\jaas.dll
+    Library\bin\java.dll
+    Library\bin\javajpeg.dll
+    Library\bin\jawt.dll
+    Library\bin\jdwp.dll
+    Library\bin\jimage.dll
+    Library\bin\jli.dll
+    Library\bin\jpackage.dll
+    Library\bin\jsound.dll
+    Library\bin\jsvml.dll
+    Library\bin\lcms.dll
+    Library\bin\le.dll
+    Library\bin\management.dll
+    Library\bin\management_agent.dll
+    Library\bin\management_ext.dll
+    Library\bin\mlib_image.dll
+    Library\bin\net.dll
+    Library\bin\nio.dll
+    Library\bin\prefs.dll
+    Library\bin\rmi.dll
+    Library\bin\saproc.dll
+    Library\bin\splashscreen.dll
+    Library\bin\sspi_bridge.dll
+    Library\bin\sunmscapi.dll
+    Library\bin\syslookup.dll
+    Library\bin\verify.dll
+    Library\bin\zip.dll
+    Library\bin\server\jvm.dll
+) do (
+    if not exist "%PREFIX%\%%f" (
+        echo MISSING library: %%f
+        exit /b 1
+    )
+)
+
+echo Checking headers...
+for %%f in (
+    Library\include\classfile_constants.h
+    Library\include\jawt.h
+    Library\include\jdwpTransport.h
+    Library\include\jni.h
+    Library\include\jvmti.h
+    Library\include\jvmticmlr.h
+) do (
+    if not exist "%PREFIX%\%%f" (
+        echo MISSING header: %%f
+        exit /b 1
+    )
+)
+
+echo All files present.

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -65,7 +65,11 @@ case "$(uname -s)" in
         ;;
     Linux)
         lib_ext="so"
-        extra_libs="lib/libawt_headless.$lib_ext lib/libawt_xawt.$lib_ext lib/libjsvml.$lib_ext lib/libmlib_image.$lib_ext lib/libsctp.$lib_ext lib/libsaproc.$lib_ext"
+        extra_libs="lib/libawt_headless.$lib_ext lib/libawt_xawt.$lib_ext lib/libmlib_image.$lib_ext lib/libsctp.$lib_ext lib/libsaproc.$lib_ext"
+        # libjsvml.so exists only on x86_64
+        if [ "$(uname -m)" = "x86_64" ]; then
+            extra_libs="$extra_libs lib/libjsvml.$lib_ext"
+        fi
         ;;
 esac
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -15,3 +15,111 @@ pushd test-nio
   jar cfm TestFilePaths.jar manifest.mf TestFilePaths.class
   java -jar TestFilePaths.jar TestFilePaths.java
 popd
+
+echo "Checking binaries..."
+for f in \
+    bin/jar \
+    bin/jarsigner \
+    bin/java \
+    bin/javac \
+    bin/javadoc \
+    bin/javap \
+    bin/jcmd \
+    bin/jconsole \
+    bin/jdb \
+    bin/jdeprscan \
+    bin/jdeps \
+    bin/jfr \
+    bin/jhsdb \
+    bin/jimage \
+    bin/jinfo \
+    bin/jlink \
+    bin/jmap \
+    bin/jmod \
+    bin/jpackage \
+    bin/jps \
+    bin/jrunscript \
+    bin/jshell \
+    bin/jstack \
+    bin/jstat \
+    bin/jstatd \
+    bin/jwebserver \
+    bin/keytool \
+    bin/rmiregistry \
+    bin/serialver \
+; do
+    if [ ! -f "$PREFIX/$f" ]; then
+        echo "MISSING binary: $f"
+        exit 1
+    fi
+done
+echo "Checking libraries..."
+case "$(uname -s)" in
+    Darwin)
+        lib_ext="dylib"
+        extra_libs="lib/libfreetype.$lib_ext lib/libawt_lwawt.$lib_ext lib/libosx.$lib_ext lib/libosxapp.$lib_ext lib/libosxkrb5.$lib_ext lib/libosxsecurity.$lib_ext lib/libosxui.$lib_ext"
+        ;;
+    Linux)
+        lib_ext="so"
+        extra_libs="lib/libawt_headless.$lib_ext lib/libawt_xawt.$lib_ext lib/libjsvml.$lib_ext lib/libmlib_image.$lib_ext lib/libsctp.$lib_ext lib/libsaproc.$lib_ext"
+        ;;
+esac
+
+for f in \
+    $lib_dir/libattach.$lib_ext \
+    $lib_dir/libawt.$lib_ext \
+    $lib_dir/libdt_socket.$lib_ext \
+    $lib_dir/libextnet.$lib_ext \
+    $lib_dir/libfontmanager.$lib_ext \
+    $lib_dir/libinstrument.$lib_ext \
+    $lib_dir/libj2gss.$lib_ext \
+    $lib_dir/libj2pcsc.$lib_ext \
+    $lib_dir/libj2pkcs11.$lib_ext \
+    $lib_dir/libjaas.$lib_ext \
+    $lib_dir/libjava.$lib_ext \
+    $lib_dir/libjavajpeg.$lib_ext \
+    $lib_dir/libjawt.$lib_ext \
+    $lib_dir/libjdwp.$lib_ext \
+    $lib_dir/libjimage.$lib_ext \
+    $lib_dir/libjli.$lib_ext \
+    $lib_dir/libjsig.$lib_ext \
+    $lib_dir/libjsound.$lib_ext \
+    $lib_dir/liblcms.$lib_ext \
+    $lib_dir/lible.$lib_ext \
+    $lib_dir/libmanagement.$lib_ext \
+    $lib_dir/libmanagement_agent.$lib_ext \
+    $lib_dir/libmanagement_ext.$lib_ext \
+    $lib_dir/libnet.$lib_ext \
+    $lib_dir/libnio.$lib_ext \
+    $lib_dir/libprefs.$lib_ext \
+    $lib_dir/librmi.$lib_ext \
+    $lib_dir/libsplashscreen.$lib_ext \
+    $lib_dir/libsyslookup.$lib_ext \
+    $lib_dir/libverify.$lib_ext \
+    $lib_dir/libzip.$lib_ext \
+    $lib_dir/server/libjsig.$lib_ext \
+    $lib_dir/server/libjvm.$lib_ext \
+    $extra_libs \
+; do
+    if [ ! -f "$PREFIX/$f" ]; then
+        echo "MISSING library: $f"
+        exit 1
+    fi
+done
+
+echo "Checking headers..."
+for f in \
+    $include_dir/classfile_constants.h \
+    $include_dir/jawt.h \
+    $include_dir/jdwpTransport.h \
+    $include_dir/jni.h \
+    $include_dir/jvmti.h \
+    $include_dir/jvmticmlr.h \
+; do
+    if [ ! -f "$PREFIX/$f" ]; then
+        echo "MISSING header: $f"
+        exit 1
+    fi
+done
+
+echo "All files present."

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -53,6 +53,10 @@ for f in \
         exit 1
     fi
 done
+
+lib_dir="lib"
+include_dir="include"
+
 echo "Checking libraries..."
 case "$(uname -s)" in
     Darwin)


### PR DESCRIPTION
openjdk 21.0.11

**Destination channel:** defaults

### Links

- [PKG-14652](https://anaconda.atlassian.net/browse/PKG-14652) 
- [Upstream repository](https://github.com/JetBrains/JetBrainsRuntime/tree/jdk-21.0.10+0)

### Explanation of changes:
- New version number
- removing dependency that are related to unsupported OS

[PKG-14652]: https://anaconda.atlassian.net/browse/PKG-14652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ