### PR TITLE
Initial win-arm64 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,15 @@ source:
   - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-{{ version }}-windows-x64-b{{ intellij_build }}.tar.gz                 # [win64]
     fn: jbr_jcef-{{ version }}-windows-x64-b{{ intellij_build }}.tar.gz                                                                      # [win64]
     sha256: cc864687b3ae87030ef3685907ca387b1b216db5cdb27f1cc211dbb9ddb958c6                                                                 # [win64]
+  - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-{{ version }}-windows-aarch64-b{{ intellij_build }}.tar.gz               # [win and arm64]
+    fn: jbrsdk-{{ version }}-windows-aarch64-b{{ intellij_build }}.tar.gz                                                                    # [win and arm64]
+    sha256: 293e8d537e7eb6e9885dc35af00fc83098817975eb8a0506cd3cf05a054b09e2                                                                 # [win and arm64]
+  - url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-{{ version }}-windows-aarch64-b{{ intellij_build }}.tar.gz             # [win and arm64]
+    fn: jbr_jcef-{{ version }}-windows-aarch64-b{{ intellij_build }}.tar.gz                                                                  # [win and arm64]
+    sha256: 65891be43ac23127645db93d6a57ea5ce40df014641fcc3603ee67290f9ad4a3                                                                 # [win and arm64]
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - dbus               # [linux]
     - expat              # [linux]

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -71,7 +71,6 @@ for %%f in (
     Library\bin\jli.dll
     Library\bin\jpackage.dll
     Library\bin\jsound.dll
-    Library\bin\jsvml.dll
     Library\bin\lcms.dll
     Library\bin\management.dll
     Library\bin\management_agent.dll
@@ -92,6 +91,14 @@ for %%f in (
 ) do (
     if not exist "%PREFIX%\%%f" (
         echo MISSING library: %%f
+        exit /b 1
+    )
+)
+
+:: jsvml.dll (Intel SVML) only ships in x64 builds, not win-arm64
+if /i "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    if not exist "%PREFIX%\Library\bin\jsvml.dll" (
+        echo MISSING library: Library\bin\jsvml.dll
         exit /b 1
     )
 )


### PR DESCRIPTION
openjdk 25.0.3
**Destination channel:** defaults

### Links

- [PKG-17417](https://anaconda.atlassian.net/browse/PKG-17417)
- [Upstream repository](https://github.com/JetBrains/JetBrainsRuntime)
- [Upstream changelog/diff](https://github.com/JetBrains/JetBrainsRuntime/releases/tag/jbr-release-25.0.3b508.16)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Added win-arm64 sources: JetBrains publishes `jbrsdk` and `jbr_jcef` `windows-aarch64` tarballs for 25.0.3-b508.16; added both with `# [win and arm64]` selectors and locally computed sha256s.
- Bumped build number 0 -> 1.
- Made the `jsvml.dll` check in `run_test.bat` x64-only (`PROCESSOR_ARCHITECTURE%==AMD64`): Intel SVML is x86-specific and not shipped in the arm64 JBR. Verified the arm64 SDK tarball against the full run_test.bat checklist -- jsvml.dll is the only difference.


[PKG-17417]: https://anaconda.atlassian.net/browse/PKG-17417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ